### PR TITLE
Adds action input for skipping type errors when running para build

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,9 @@ URL for Paragon Zeus.
 
 - `paragonDashboardUrl` (Optional)\
 URL for Paragon Dashboard.
+
+- `subfolder` (Optional)\
+Specify base path to Paragraph project, relative to the working directory
+
+- `skipTypeErrors` (Optional)\
+Skip type error checks when building the Paragraph project.

--- a/action.yml
+++ b/action.yml
@@ -17,8 +17,14 @@ inputs:
     default: "https://dashboard.useparagon.com"
   subfolder:
     type: string
+    description: 'Specify base path to Paragraph project, relative to the working directory.'
     required: false
     default: '.'
+  skipTypeErrors:
+    type: boolean
+    description: 'Skip type error checks when building the Paragraph project.'
+    required: false
+    default: false
 
 runs:
   using: 'composite'
@@ -116,7 +122,12 @@ runs:
       working-directory: ${{ inputs.subfolder }}
       run: |
         npx para install
-        npx para build
+        if [ "${{ inputs.skipTypeErrors }}" = "true" ]; then
+          echo "::info::Skipping type errors during para build"
+          npx para build --skip-type-errors
+        else
+          npx para build
+        fi
 
     - name: Push to Paragon
       shell: bash

--- a/action.yml
+++ b/action.yml
@@ -123,7 +123,7 @@ runs:
       run: |
         npx para install
         if [ "${{ inputs.skipTypeErrors }}" = "true" ]; then
-          echo "::info::Skipping type errors during para build"
+          echo "::notice::Skipping type errors during para build"
           npx para build --skip-type-errors
         else
           npx para build


### PR DESCRIPTION
- add an optional `skipTypeErrors` param for ignoring type errors on `para build`
- update README to include undocumented `subfolder` param and include description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an optional `skipTypeErrors` input to conditionally skip type errors during `para build` and documents the `subfolder` input.
> 
> - **Action (`action.yml`)**:
>   - **Inputs**: Add `skipTypeErrors` (boolean, default `false`); add description to `subfolder`.
>   - **Build step**: Conditionally run `npx para build --skip-type-errors` when `inputs.skipTypeErrors` is `true`; otherwise run `npx para build`.
> - **Docs (`README.md`)**:
>   - Document `subfolder` and `skipTypeErrors` inputs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b69cea7ecaa545343e7b4e0a2b1d96b2ff92b04. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->